### PR TITLE
Bruh/package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+# Exit on error
+set -e
+
+# Log commands
+set -x
+
+# Install specific Python version if not available
+if ! command -v python3.8 &> /dev/null; then
+    echo "Installing Python 3.8..."
+    apt-get update
+    apt-get install -y python3.8 python3.8-dev python3.8-distutils
+    ln -sf /usr/bin/python3.8 /usr/bin/python3
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    python3.8 get-pip.py
+    rm get-pip.py
+fi
+
+# Install server Node.js dependencies
+cd server
+npm ci
+
+# Install Python requirements
+python3.8 -m pip install --upgrade pip
+python3.8 -m pip install -r requirements.txt
+cd ..
+
+# Make the build script executable
+chmod +x build.sh
+
+# Print versions for debugging
+python3.8 --version
+node --version
+npm --version

--- a/client/src/services/apiService.js
+++ b/client/src/services/apiService.js
@@ -2,7 +2,7 @@
  * API service to handle communications with the server
  */
 
-const API_URL = '/api';
+const API_URL = 'https://vsl-interpreter.onrender.com/api';
 
 /**
  * Send landmarks data to the server for live video translation

--- a/client/src/services/apiService.js
+++ b/client/src/services/apiService.js
@@ -2,7 +2,7 @@
  * API service to handle communications with the server
  */
 
-const API_URL = 'http://localhost:3001/api';
+const API_URL = '/api';
 
 /**
  * Send landmarks data to the server for live video translation

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,16 +1,23 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
-        secure: false,
+export default defineConfig(({ command }) => {
+  const config = {
+    plugins: [react()],
+  };
+  
+  if (command === 'serve') {
+    // Development proxy settings
+    config.server = {
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3001',
+          changeOrigin: true,
+          secure: false,
+        },
       },
-    },
-  },
-})
+    };
+  }
+  
+  return config;
+});


### PR DESCRIPTION
## Summary by Sourcery

Introduce conditional development proxy in Vite, update the client to use the production API endpoint, and add a build script to automate environment setup and dependency installation.

New Features:
- Add build.sh script to automate Python 3.8 setup, install server dependencies, and configure the build environment

Enhancements:
- Configure Vite to apply the /api proxy only in development mode
- Switch client API base URL to the deployed production endpoint